### PR TITLE
add support for optionally writing metric data as json

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,9 @@ spIgnoreProvided := true
 sparkVersion := "2.1.1"
 
 libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.1.1"
+libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.6.5"
 libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.25"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.3" % "test"
 libraryDependencies += "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.9.1" % "test"
 
 organization := "ch.cern.sparkmeasure"

--- a/src/main/scala/ch/cern/sparkmeasure/utils.scala
+++ b/src/main/scala/ch/cern/sparkmeasure/utils.scala
@@ -4,6 +4,7 @@ import scala.collection.mutable.ListBuffer
 import java.io._
 import java.nio.file.Paths
 
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
@@ -19,6 +20,8 @@ object Utils {
 
   val objectMapper = new ObjectMapper with ScalaObjectMapper
   objectMapper.registerModule(DefaultScalaModule)
+  val objectWriter = objectMapper.writer(new DefaultPrettyPrinter())
+
 
   /** boilerplate code for pretty printing, formatDuration code borrowed from Spark UIUtils */
   def formatDuration(milliseconds: Long): String = {
@@ -124,7 +127,7 @@ object Utils {
   def writeSerializedJSON(fullPath: String, metricsData: AnyRef): Unit = {
     val os = new FileOutputStream(fullPath)
     try {
-      objectMapper.writeValue(os, metricsData)
+      objectWriter.writeValue(os, metricsData)
     } finally {
       os.close()
     }

--- a/src/test/scala/ch/cern/sparkmeasure/UtilsTest.scala
+++ b/src/test/scala/ch/cern/sparkmeasure/UtilsTest.scala
@@ -1,0 +1,84 @@
+package ch.cern.sparkmeasure
+
+import java.io.File
+
+import scala.collection.mutable.ListBuffer
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class UtilsTest extends FlatSpec with Matchers {
+
+  val stageVals0 = StageVals(jobId = 1, stageId = 2, name = "stageVal",
+    submissionTime = 10, completionTime = 11, stageDuration = 12, numTasks = 13,
+    executorRunTime = 14, executorCpuTime = 15,
+    executorDeserializeTime = 16, executorDeserializeCpuTime = 17,
+    resultSerializationTime = 18, jvmGCTime = 19, resultSize = 20, numUpdatedBlockStatuses = 21,
+    diskBytesSpilled = 30, memoryBytesSpilled = 31, peakExecutionMemory = 32, recordsRead = 33,
+    bytesRead = 34, recordsWritten = 35, bytesWritten = 36,
+    shuffleFetchWaitTime = 40, shuffleTotalBytesRead = 41, shuffleTotalBlocksFetched = 42,
+    shuffleLocalBlocksFetched = 43, shuffleRemoteBlocksFetched = 44, shuffleWriteTime = 45,
+    shuffleBytesWritten = 46, shuffleRecordsWritten = 47
+  )
+
+  val taskVals0 = TaskVals(jobId = 1, stageId = 2, index = 3, launchTime = 4, finishTime = 5,
+    duration = 10, schedulerDelay = 11, executorId = "exec0", host = "host0", taskLocality = 12,
+    speculative = false, gettingResultTime = 12, successful = true,
+    executorRunTime = 14, executorCpuTime = 15,
+    executorDeserializeTime = 16, executorDeserializeCpuTime = 17,
+    resultSerializationTime = 18, jvmGCTime = 19, resultSize = 20, numUpdatedBlockStatuses = 21,
+    diskBytesSpilled = 30, memoryBytesSpilled = 31, peakExecutionMemory = 32, recordsRead = 33,
+    bytesRead = 34, recordsWritten = 35, bytesWritten = 36,
+    shuffleFetchWaitTime = 40, shuffleTotalBytesRead = 41, shuffleTotalBlocksFetched = 42,
+    shuffleLocalBlocksFetched = 43, shuffleRemoteBlocksFetched = 44, shuffleWriteTime = 45,
+    shuffleBytesWritten = 46, shuffleRecordsWritten = 47
+  )
+
+  it should "write and read back StageVal (Java Serialization)" in {
+    val file = File.createTempFile("stageVal", ".tmp")
+    try {
+      Utils.writeSerialized(file.getAbsolutePath, ListBuffer(stageVals0))
+      val stageVals = Utils.readSerializedStageMetrics(file.getAbsolutePath)
+      stageVals should have length 1
+      stageVals.head shouldEqual stageVals0
+    } finally {
+      file.delete()
+    }
+  }
+
+  it should "write and read back TaskVal (Java Serialization)" in {
+    val file = File.createTempFile("taskVal", ".tmp")
+    try {
+      Utils.writeSerialized(file.getAbsolutePath, ListBuffer(taskVals0))
+      val taskVals = Utils.readSerializedTaskMetrics(file.getAbsolutePath)
+      taskVals should have length 1
+      taskVals.head shouldEqual taskVals0
+    } finally {
+      file.delete()
+    }
+  }
+
+  it should "write and read back StageVal JSON" in {
+    val file = File.createTempFile("stageVal", ".json")
+    try {
+      Utils.writeSerializedJSON(file.getAbsolutePath, ListBuffer(stageVals0))
+      val stageVals = Utils.readSerializedStageMetricsJSON(file.getAbsolutePath)
+      stageVals should have length 1
+      stageVals.head shouldEqual stageVals0
+    } finally {
+      file.delete()
+    }
+  }
+
+  it should "write and read back TaskVal JSON" in {
+    val file = File.createTempFile("taskVal", ".json")
+    try {
+      Utils.writeSerializedJSON(file.getAbsolutePath, ListBuffer(taskVals0))
+      val taskVals = Utils.readSerializedTaskMetricsJSON(file.getAbsolutePath)
+      taskVals should have length 1
+      taskVals.head shouldEqual taskVals0
+    } finally {
+      file.delete()
+    }
+  }
+
+}


### PR DESCRIPTION
Relates to https://github.com/LucaCanali/sparkMeasure/issues/3

Spark already uses Jackson Scala Module 2.6.5 so this seems like the best lib to use.