### PR TITLE
Handle null values when generating report string from task metrics

### DIFF
--- a/src/main/scala/ch/cern/sparkmeasure/taskmetrics.scala
+++ b/src/main/scala/ch/cern/sparkmeasure/taskmetrics.scala
@@ -204,8 +204,8 @@ case class TaskMetrics(sparkSession: SparkSession, gatherAccumulables: Boolean =
     val cols = aggregateDF.columns
     result = result :+ ((cols zip aggregateValues)
       .map {
-        case ((n: String, v: Long)) =>
-          Utils.prettyPrintValues(n, v)
+        case ((n: String, v: Long)) => Utils.prettyPrintValues(n, v)
+        case ((n: String, null)) => n + " => null"
       }).mkString("\n")
 
     return (result.mkString("\n"))


### PR DESCRIPTION
Fixes https://github.com/LucaCanali/sparkMeasure/issues/20