### PR TITLE
New maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,15 +98,6 @@
 		    <version>1.0.0</version>
 		</dependency>		
 		<!-- https://mvnrepository.com/artifact/com.github.tomakehurst/wiremock -->
-		<!-- com.github.tomakehurst repalced by org.wiremock  
-		<dependency>
-		    <groupId>com.github.tomakehurst</groupId>
-		    <artifactId>wiremock</artifactId>
-		    <version>2.23.2</version>
-		    <type>pom</type>
-		    <scope>test</scope>
-		</dependency>
-		-->
 	</dependencies>
 	<build>
 		<sourceDirectory>src/main/scala</sourceDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,243 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>ch.cern.sparkMeasure</groupId>
+  <artifactId>sparkMeasure</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>Spark Measure</name>
+  <description>Performance Measurement for Spark SQL</description>
+  
+    <properties>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
+		<encoding>UTF-8</encoding>
+		<scala.version>2.11.12</scala.version>
+		<scala.compat.version>2.12</scala.compat.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.spark</groupId>
+			<artifactId>spark-core_2.11</artifactId>
+			<version>2.4.4</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+		<!--  -->
+			<groupId>org.apache.spark</groupId>
+			<artifactId>spark-sql_2.11</artifactId>
+			<version>2.4.4</version>
+			<scope>compile</scope>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.apache.spark/spark-mllib -->
+		<dependency>
+			<groupId>org.apache.spark</groupId>
+			<artifactId>spark-mllib_2.11</artifactId>
+			<version>2.4.4</version>
+		</dependency>
+		<!--    ***** Spark Measure dependency from build.sbt ***** -->
+		<!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.module/jackson-module-scala -->
+		<dependency>
+		    <groupId>com.fasterxml.jackson.module</groupId>
+		    <artifactId>jackson-module-scala_2.11</artifactId>
+		    <version>2.9.10</version>
+		</dependency>
+		<dependency>
+	        <groupId>com.fasterxml.jackson.core</groupId>
+	        <artifactId>jackson-databind</artifactId>
+	        <version>2.6.5</version>
+	    </dependency>
+		<!--    ***** Spark Measure dependency ***** -->
+	    <!-- https://mvnrepository.com/artifact/org.influxdb/influxdb-java -->
+		<dependency>
+		    <groupId>org.influxdb</groupId>
+		    <artifactId>influxdb-java</artifactId>
+		    <version>2.14</version>
+		</dependency>
+		<!--    ***** Spark Measure dependency from build.sbt 1.7.26 ***** -->
+		<dependency>
+		    <groupId>org.apache.logging.log4j</groupId>
+		    <artifactId>log4j-api</artifactId>
+		    <version>2.11.0</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
+		<dependency>
+		    <groupId>org.apache.logging.log4j</groupId>
+		    <artifactId>log4j-core</artifactId>
+		    <version>2.11.0</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api-scala -->
+		<dependency>
+		    <groupId>org.apache.logging.log4j</groupId>
+		    <artifactId>log4j-api-scala_2.11</artifactId>
+		    <version>11.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.scala-lang</groupId>
+			<artifactId>scala-library</artifactId>
+			<version>2.11.8</version>
+		</dependency>
+		<!-- Test -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<scope>test</scope>
+		</dependency>
+		<!--    ***** Spark Measure dependency from build.sbt 1.7.26 ***** -->
+		<!-- https://mvnrepository.com/artifact/org.scalatest/scalatest -->
+		<dependency>
+		    <groupId>org.scalatest</groupId>
+		    <artifactId>scalatest_2.11</artifactId>
+		    <version>3.0.8</version>
+		    <scope>test</scope>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.wiremock/wiremock-webhooks-extension -->
+		<dependency>
+		    <groupId>org.wiremock</groupId>
+		    <artifactId>wiremock-webhooks-extension</artifactId>
+		    <version>1.0.0</version>
+		</dependency>		
+		<!-- https://mvnrepository.com/artifact/com.github.tomakehurst/wiremock -->
+		<!-- com.github.tomakehurst repalced by org.wiremock  
+		<dependency>
+		    <groupId>com.github.tomakehurst</groupId>
+		    <artifactId>wiremock</artifactId>
+		    <version>2.23.2</version>
+		    <type>pom</type>
+		    <scope>test</scope>
+		</dependency>
+		-->
+	</dependencies>
+	<build>
+		<sourceDirectory>src/main/scala</sourceDirectory>
+		<testSourceDirectory>src/test/scala</testSourceDirectory>
+		<plugins>
+			<plugin>
+				<!-- see http://davidb.github.com/scala-maven-plugin -->
+				<groupId>net.alchim31.maven</groupId>
+				<artifactId>scala-maven-plugin</artifactId>
+				<version>3.3.1</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>compile</goal>
+							<goal>testCompile</goal>
+						</goals>
+						<configuration>
+							<args>
+								<arg>-feature</arg>
+								<arg>-deprecation</arg>
+								<arg>-dependencyfile</arg>
+								<arg>${project.build.directory}/.scala_dependencies</arg>
+							</args>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.18.1</version>
+				<configuration>
+					<useFile>false</useFile>
+					<disableXmlReport>true</disableXmlReport>
+					<!-- If you have classpath issue like NoDefClassError,... -->
+					<!-- useManifestOnlyJar>false</useManifestOnlyJar -->
+					<includes>
+						<include>**/*Test.*</include>
+						<include>**/*Suite.*</include>
+					</includes>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>1.5.0</version>
+				<executions>
+					<execution>
+						<id>run-local</id>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+						<configuration>
+							<executable>spark-submit</executable>
+							<arguments>
+								<argument>--master</argument>
+								<argument>local</argument>
+								<argument>${project.build.directory}/${project.artifactId}-${project.version}-uber.jar</argument>
+							</arguments>
+						</configuration>
+					</execution>
+					<execution>
+						<id>run-yarn</id>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+						<configuration>
+							<environmentVariables>
+								<HADOOP_CONF_DIR>
+									${basedir}/spark-remote/conf
+								</HADOOP_CONF_DIR>
+							</environmentVariables>
+							<executable>spark-submit</executable>
+							<arguments>
+								<argument>--master</argument>
+								<argument>yarn</argument>
+								<argument>${project.build.directory}/${project.artifactId}-${project.version}-uber.jar</argument>
+							</arguments>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<!-- Use the shade plugin to remove all the provided artifacts (such as 
+				spark itself) from the uber jar -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.1.0</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<!-- Remove signed keys to prevent security exceptions on uber jar -->
+							<!-- See https://stackoverflow.com/a/6743609/7245239 -->
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/*.SF</exclude>
+										<exclude>META-INF/*.DSA</exclude>
+										<exclude>META-INF/*.RSA</exclude>
+									</excludes>
+								</filter>
+							</filters>
+							<transformers>
+								<transformer
+									implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<manifestEntries>
+										<Main-Class>net.martinprobson.spark.spark_example.SparkTest</Main-Class>
+									</manifestEntries>
+								</transformer>
+							</transformers>
+							<artifactSet>
+								<excludes>
+									<exclude>javax.servlet:*</exclude>
+									<exclude>org.apache.hadoop:*</exclude>
+									<exclude>org.apache.maven.plugins:*</exclude>
+									<exclude>org.apache.spark:*</exclude>
+									<exclude>org.apache.avro:*</exclude>
+									<exclude>org.apache.parquet:*</exclude>
+									<exclude>org.scala-lang:*</exclude>
+								</excludes>
+							</artifactSet>
+							<finalName>${project.artifactId}-${project.version}-uber</finalName>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>  
+</project>


### PR DESCRIPTION
This has the following issues:
1. build.sbt was not functional on a mac running Eclipse Oxygen Scala IDE 4.7.0-vfinal-2017-09-29
2. legacy applications required Scala 2.11 instead of 2.12 (which seems like sbt would handle but maven would not)
3. Wiremock is no longer available through com.github.tomakehurst and was pulled through org.wiremock instead.
4. There are warnings in the maven build that 
[WARNING] Scala library detected 2.11.12 doesn't match scala.compat.version : 2.12.-1
[WARNING]  Expected all dependencies to require Scala version: 2.12.-1
[WARNING]  com.twitter:chill_2.11:0.9.3 requires scala version: 2.11.12
[WARNING] Multiple versions of scala libraries detected!
5. because I am not set up for influxDB there are additional build warnings for that.

Tests run successfully.

If you soundly reject this because the Mavin build does not make sense given the SBT build is able to create multi-versions of the repository (skava 2.11 & 2.12) I get that.  Just needed a way to verify the build before I start modifying the project.