### PR TITLE
The approach is to deliver a Scala Map rather than a JSON object. 

### DIFF
--- a/src/main/scala/ch/cern/sparkmeasure/stagemetrics.scala
+++ b/src/main/scala/ch/cern/sparkmeasure/stagemetrics.scala
@@ -180,12 +180,10 @@ case class StageMetrics(sparkSession: SparkSession) {
     val cols = aggregateDF.columns
     (cols zip aggregates)
       .foreach {
-        case(n:String, v:Long) =>
-          resultMap.put(n, v.toString)
-        case(n:String, v:String) => 
-          resultMap.put(n, v.toString)
         case(n:String, null) =>
             resultMap.put(n, s"no data returned")
+        case(n,v) =>
+          resultMap.put(n.toString , v.toString)
       }        
     resultMap
   }


### PR DESCRIPTION
There are two additions with the pull request:
1) The aggregateStageMetrics query has been changed to have a series of "as" column names added.  This has the effect of changing the standard.out report to have the value instead of the sum(value).  The user sees this:
**stageDuration => 458 (0.5 s)**
instead of the full query they currently see through 0.15:
**sum(stageDuration) => 476 (0.5 s)**
This change was made specifically so that data formatted output could have a concise key values without special characters like this:
```
"message" : {...
    "stageDuration" : "458",
     ...}
```
rather than this:
```
"message" : {...
    "sum(stageDuration)" : "458",
     ...}
```

2) There is a new reportMap() that returns a Scala Map.  The Map allows for JSON, CSV, XML or other format.  The user can also modify (add information to the map object).

reportMap() is then called AFTER runAndMeasure with the following use case:

2.1) user does sparkMeasure
```
val df :DataFrame =
stageMetrics.runAndMeasure(fillDataFrame(spark,format,
connectionProperties, query))
```
2.2) user calls reportMap() to get the map
`stageMetrics.reportMap()`
2.3) User is able to manipulate the map:
```
    map.put("id", "2")
    map.put("event", "queryStructure")
    map.put("queryName", name)
```
2.4) User converts map to desired output:
`val msg = new org.apache.logging.log4j.message.ObjectMessage(map)`