### PR TITLE
add ability to specify saveMode while writing spark results.

### DIFF
--- a/src/main/scala/ch/cern/sparkmeasure/stagemetrics.scala
+++ b/src/main/scala/ch/cern/sparkmeasure/stagemetrics.scala
@@ -327,8 +327,8 @@ case class StageMetrics(sparkSession: SparkSession) {
   }
 
   /** Helper method to save data, we expect to have small amounts of data so collapsing to 1 partition seems OK */
-  def saveData(df: DataFrame, fileName: String, fileFormat: String = "json") = {
-    df.repartition(1).write.format(fileFormat).save(fileName)
+  def saveData(df: DataFrame, fileName: String, fileFormat: String = "json", saveMode: String = "default") = {
+    df.repartition(1).write.format(fileFormat).mode(saveMode).save(fileName)
     logger.warn(s"Stage metric data saved into $fileName using format=$fileFormat")
   }
   

--- a/src/main/scala/ch/cern/sparkmeasure/taskmetrics.scala
+++ b/src/main/scala/ch/cern/sparkmeasure/taskmetrics.scala
@@ -272,8 +272,8 @@ case class TaskMetrics(sparkSession: SparkSession, gatherAccumulables: Boolean =
   }
 
   /** helper method to save data, we expect to have moderate amounts of data so collapsing to 1 partition seems OK */
-  def saveData(df: DataFrame, fileName: String, fileFormat: String = "json") = {
-    df.repartition(1).write.format(fileFormat).save(fileName)
+  def saveData(df: DataFrame, fileName: String, fileFormat: String = "json", saveMode: String = "default") = {
+    df.repartition(1).write.format(fileFormat).mode(saveMode).save(fileName)
     logger.warn(s"Task metric data saved into $fileName using format=$fileFormat")
   }
 


### PR DESCRIPTION
This is required if someone wants to allow spark to overwrite existing stagemetrics results file.