### PR TITLE
Fix Python TaskMetrics.__init__

### DIFF
--- a/python/sparkmeasure/taskmetrics.py
+++ b/python/sparkmeasure/taskmetrics.py
@@ -13,7 +13,7 @@ class TaskMetrics:
     def __init__(self, sparksession):
         self.sparksession = sparksession
         self.sc = self.sparksession.sparkContext
-        self.taskmetrics = self.sc._jvm.ch.cern.sparkmeasure.TaskMetrics(self.sparksession._jsparkSession, False)
+        self.taskmetrics = self.sc._jvm.ch.cern.sparkmeasure.TaskMetrics(self.sparksession._jsparkSession)
 
     def begin(self):
         self.taskmetrics.begin()


### PR DESCRIPTION
`gatherAccumulable` was removed from the constructor from the parallel
Scala TaskMetrics class; however, the Python constructor was not
updated.

In sparkmeasure pypi 0.21.0 I saw the following error upon running the Python constructor.
py4j.Py4JException: Constructor ch.cern.sparkmeasure.TaskMetrics([class org.apache.spark.sql.SparkSession, class java.lang.Boolean]) does not exist

https://github.com/LucaCanali/sparkMeasure/blob/131e52b0d64b9cd018f998913266c16cc88ef2a4/src/main/scala/ch/cern/sparkmeasure/TaskMetrics.scala#L21

I tested this with a local Python build and ensure that I was able to construct TaskMetrics and collect metrics.