### PR TITLE
Added connection & read timeout configuration for pushgateway sink

### DIFF
--- a/docs/Flight_recorder_mode_PrometheusPushgatewaySink.md
+++ b/docs/Flight_recorder_mode_PrometheusPushgatewaySink.md
@@ -33,6 +33,10 @@ Configuration - PushGatewaySink parameters:
        Example: --conf spark.sparkmeasure.pushgateway=localhost:9091
 --conf spark.sparkmeasure.pushgateway.jobname=JOBNAME // defaut value is pushgateway
        Example: --conf spark.sparkmeasure.pushgateway.jobname=myjob1
+--conf spark.sparkmeasure.pushgateway.http.connection.timeout=TIME_IN_MS // defaut value is 5000
+       Example: --conf spark.sparkmeasure.pushgateway.http.connection.timeout=150
+--conf spark.sparkmeasure.pushgateway.http.read.timeout=TIME_IN_MS // defaut value is 5000
+       Example: --conf spark.sparkmeasure.pushgateway.http.read.timeout=150
 ```
 
 ## Use case

--- a/src/main/scala/ch/cern/sparkmeasure/PushGatewaySink.scala
+++ b/src/main/scala/ch/cern/sparkmeasure/PushGatewaySink.scala
@@ -31,8 +31,9 @@ class PushGatewaySink(conf: SparkConf) extends SparkListener {
   logger.warn("Custom monitoring listener with Prometheus Push Gateway sink initializing. Now attempting to connect to the Push Gateway")
 
   // Initialize PushGateway connection
-  val (url, job) = Utils.parsePushGatewayConfig(conf, logger)
-  val gateway = PushGateway(url, job)
+  private val gateway: PushGateway = PushGateway(
+    Utils.parsePushGatewayConfig(conf, logger)
+  )
 
   var appId: String = SparkSession.getActiveSession match {
     case Some(sparkSession) => sparkSession.sparkContext.applicationId

--- a/src/main/scala/ch/cern/sparkmeasure/StageMetrics.scala
+++ b/src/main/scala/ch/cern/sparkmeasure/StageMetrics.scala
@@ -4,12 +4,12 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters.mapAsJavaMap
-import scala.collection.mutable.{ListBuffer, LinkedHashMap}
-import scala.math.{min, max}
+import scala.collection.mutable.{LinkedHashMap, ListBuffer}
+import scala.math.{max, min}
 
 /**
- *  Stage Metrics: collects stage-level metrics with Stage granularity
- *  and provides aggregation and reporting functions for the end-user
+ * Stage Metrics: collects stage-level metrics with Stage granularity
+ * and provides aggregation and reporting functions for the end-user
  *
  * Example:
  * val stageMetrics = ch.cern.sparkmeasure.StageMetrics(spark)
@@ -39,7 +39,7 @@ case class StageMetrics(sparkSession: SparkSession) {
 
   // Marks the beginning of data collection
   def begin(): Long = {
-    listenerStage.stageMetricsData.clear()    // clear previous data to reduce memory footprint
+    listenerStage.stageMetricsData.clear() // clear previous data to reduce memory footprint
     beginSnapshot = System.currentTimeMillis()
     endSnapshot = beginSnapshot
     beginSnapshot
@@ -63,7 +63,7 @@ case class StageMetrics(sparkSession: SparkSession) {
 
   // Compute basic aggregations of the Stage metrics for the metrics report
   // also filter op the time boundaries for the report
-  def aggregateStageMetrics() : LinkedHashMap[String, Long] = {
+  def aggregateStageMetrics(): LinkedHashMap[String, Long] = {
 
     val agg = Utils.zeroMetricsStage()
     var submissionTime = Long.MaxValue
@@ -108,14 +108,14 @@ case class StageMetrics(sparkSession: SparkSession) {
   }
 
   // Transforms aggregateStageMetrics output in a Java Map, needed by the Python API
-  def aggregateStageMetricsJavaMap() : java.util.Map[String, Long] = {
+  def aggregateStageMetricsJavaMap(): java.util.Map[String, Long] = {
     mapAsJavaMap(aggregateStageMetrics())
   }
 
   // Extracts stages and their duration
-  def stagesDuration() : LinkedHashMap[Int, Long] = {
+  def stagesDuration(): LinkedHashMap[Int, Long] = {
 
-    val stages : LinkedHashMap[Int, Long] = LinkedHashMap.empty[Int,Long]
+    val stages: LinkedHashMap[Int, Long] = LinkedHashMap.empty[Int, Long]
     for (metrics <- listenerStage.stageMetricsData.sortBy(_.stageId)
          if (metrics.submissionTime >= beginSnapshot && metrics.completionTime <= endSnapshot)) {
       stages += (metrics.stageId -> metrics.stageDuration)
@@ -166,10 +166,12 @@ case class StageMetrics(sparkSession: SparkSession) {
   // between the end of the job and the time the last metrics value is received
   // if you receive the error message java.util.NoSuchElementException: key not found:
   // retry to run the report after a few seconds
-    def reportMemory(): String = {
+  def reportMemory(): String = {
 
     var result = ListBuffer[String]()
-    val stages = {for (metrics <- listenerStage.stageMetricsData) yield metrics.stageId}.sorted
+    val stages = {
+      for (metrics <- listenerStage.stageMetricsData) yield metrics.stageId
+    }.sorted
 
     // Additional details on executor (memory) metrics
     result = result :+ "\nAdditional stage-level executor metrics (memory usage info):\n"
@@ -194,7 +196,7 @@ case class StageMetrics(sparkSession: SparkSession) {
             if (executorMaxVal != "driver") {
               s" on executor $executorMaxVal"
             } else {
-            ""
+              ""
             }
           result = result :+ (messageHead + messageTail)
         }
@@ -235,14 +237,14 @@ case class StageMetrics(sparkSession: SparkSession) {
       s"max(completionTime) - min(submissionTime) as elapsedTime, sum(stageDuration) as stageDuration , " +
       s"sum(executorRunTime) as executorRunTime, sum(executorCpuTime) as executorCpuTime, " +
       s"sum(executorDeserializeTime) as executorDeserializeTime, sum(executorDeserializeCpuTime) as executorDeserializeCpuTime, " +
-      s"sum(resultSerializationTime) as resultSerializationTime, sum(jvmGCTime) as jvmGCTime, "+
+      s"sum(resultSerializationTime) as resultSerializationTime, sum(jvmGCTime) as jvmGCTime, " +
       s"sum(shuffleFetchWaitTime) as shuffleFetchWaitTime, sum(shuffleWriteTime) as shuffleWriteTime, " +
       s"max(resultSize) as resultSize, " +
       s"sum(diskBytesSpilled) as diskBytesSpilled, sum(memoryBytesSpilled) as memoryBytesSpilled, " +
       s"max(peakExecutionMemory) as peakExecutionMemory, sum(recordsRead) as recordsRead, sum(bytesRead) as bytesRead, " +
       s"sum(recordsWritten) as recordsWritten, sum(bytesWritten) as bytesWritten, " +
-      s"sum(shuffleRecordsRead) as shuffleRecordsRead, sum(shuffleTotalBlocksFetched) as shuffleTotalBlocksFetched, "+
-      s"sum(shuffleLocalBlocksFetched) as shuffleLocalBlocksFetched, sum(shuffleRemoteBlocksFetched) as shuffleRemoteBlocksFetched, "+
+      s"sum(shuffleRecordsRead) as shuffleRecordsRead, sum(shuffleTotalBlocksFetched) as shuffleTotalBlocksFetched, " +
+      s"sum(shuffleLocalBlocksFetched) as shuffleLocalBlocksFetched, sum(shuffleRemoteBlocksFetched) as shuffleRemoteBlocksFetched, " +
       s"sum(shuffleTotalBytesRead) as shuffleTotalBytesRead, sum(shuffleLocalBytesRead) as shuffleLocalBytesRead, " +
       s"sum(shuffleRemoteBytesRead) as shuffleRemoteBytesRead, sum(shuffleRemoteBytesReadToDisk) as shuffleRemoteBytesReadToDisk, " +
       s"sum(shuffleBytesWritten) as shuffleBytesWritten, sum(shuffleRecordsWritten) as shuffleRecordsWritten " +
@@ -269,10 +271,10 @@ case class StageMetrics(sparkSession: SparkSession) {
       result = result :+ "Aggregated Spark stage metrics:"
       val cols = aggregateDF.columns
       result = result :+ (cols zip aggregateValues)
-        .map{
-          case(n:String, v:Long) => Utils.prettyPrintValues(n, v)
-          case(n: String, null) => n + " => null"
-          case(_,_) => ""
+        .map {
+          case (n: String, v: Long) => Utils.prettyPrintValues(n, v)
+          case (n: String, null) => n + " => null"
+          case (_, _) => ""
         }.mkString("\n")
     } else {
       result = result :+ " no data to report "
@@ -314,13 +316,18 @@ case class StageMetrics(sparkSession: SparkSession) {
     val aggregatedMetrics = aggregateStageMetrics()
 
     /** Prepare a summary of the stage metrics for Prometheus. */
-    val pushGateway = PushGateway(serverIPnPort, metricsJob)
-    var str_metrics = s""
+    val pushGateway = PushGateway(
+      PushgatewayConfig(
+        serverIPnPort = serverIPnPort,
+        jobName = metricsJob
+      )
+    )
 
+    var str_metrics = s""
     aggregatedMetrics.foreach {
       case (metric: String, value: Long) =>
-          str_metrics += pushGateway.validateMetric(metric.toLowerCase()) + s" " + value.toString + s"\n"
-      }
+        str_metrics += pushGateway.validateMetric(metric.toLowerCase()) + s" " + value.toString + s"\n"
+    }
 
     /** Send stage metrics to Prometheus. */
     val metricsType = s"stage"

--- a/src/main/scala/ch/cern/sparkmeasure/TaskMetrics.scala
+++ b/src/main/scala/ch/cern/sparkmeasure/TaskMetrics.scala
@@ -219,9 +219,14 @@ case class TaskMetrics(sparkSession: SparkSession) {
     val aggregatedMetrics = aggregateTaskMetrics()
 
     /** Prepare a summary of the task metrics for Prometheus. */
-    val pushGateway = PushGateway(serverIPnPort, metricsJob)
-    var str_metrics = s""
+    val pushGateway = PushGateway(
+      PushgatewayConfig(
+        serverIPnPort = serverIPnPort,
+        jobName = metricsJob
+      )
+    )
 
+    var str_metrics = s""
     aggregatedMetrics.foreach {
       case (metric: String, value: Long) =>
           str_metrics += pushGateway.validateMetric(metric.toLowerCase()) + s" " + value.toString + s"\n"

--- a/src/main/scala/ch/cern/sparkmeasure/Utils.scala
+++ b/src/main/scala/ch/cern/sparkmeasure/Utils.scala
@@ -1,10 +1,19 @@
 package ch.cern.sparkmeasure
 
-import org.slf4j.Logger
 import org.apache.spark.SparkConf
 import org.apache.spark.scheduler.TaskLocality
+import org.slf4j.Logger
 
 import scala.collection.mutable.LinkedHashMap
+
+/**
+ * @param serverIPnPort       String with prometheus pushgateway hostIP:Port
+ * @param jobName             the name of the spark job
+ * @param connectionTimeoutMs connection timeout for the http client, default is 5000ms
+ * @param readTimeoutMs       read timeout for the http client, default is 5000ms
+ */
+case class PushgatewayConfig(serverIPnPort: String, jobName: String, connectionTimeoutMs: Int = 5000, readTimeoutMs: Int = 5000)
+
 
 /**
  * The object Utils contains some helper code for the sparkMeasure package
@@ -36,20 +45,20 @@ object Utils {
   }
 
   def formatBytes(bytes: Long): String = {
-    val trillion = 1024L*1024L*1024L*1024L
-    val billion = 1024L*1024L*1024L
-    val million = 1024L*1024L
+    val trillion = 1024L * 1024L * 1024L * 1024L
+    val billion = 1024L * 1024L * 1024L
+    val million = 1024L * 1024L
     val thousand = 1024L
     val bytesDouble = bytes.toDouble
 
     val (value, unit): (Double, String) = {
-      if (bytesDouble >= 2*trillion) {
+      if (bytesDouble >= 2 * trillion) {
         (bytesDouble / trillion, " TB")
-      } else if (bytes >= 2*billion) {
+      } else if (bytes >= 2 * billion) {
         (bytesDouble / billion, " GB")
-      } else if (bytes >= 2*million) {
+      } else if (bytes >= 2 * million) {
         (bytesDouble / million, " MB")
-      } else if (bytes >= 2*thousand) {
+      } else if (bytes >= 2 * thousand) {
         (bytesDouble / thousand, " KB")
       } else {
         (bytesDouble, " Bytes")
@@ -63,7 +72,7 @@ object Utils {
   }
 
   // Return the data structure use to compute metrics reports for StageMetrics
-  def zeroMetricsStage() : LinkedHashMap[String, Long] = {
+  def zeroMetricsStage(): LinkedHashMap[String, Long] = {
     val zeroedMetrics = LinkedHashMap(
       "numStages" -> 0L,
       "numTasks" -> 0L,
@@ -75,8 +84,8 @@ object Utils {
       "executorDeserializeCpuTime" -> 0L,
       "resultSerializationTime" -> 0L,
       "jvmGCTime" -> 0L,
-      "shuffleFetchWaitTime"-> 0L,
-      "shuffleWriteTime"-> 0L,
+      "shuffleFetchWaitTime" -> 0L,
+      "shuffleWriteTime" -> 0L,
       "resultSize" -> 0L,
       "diskBytesSpilled" -> 0L,
       "memoryBytesSpilled" -> 0L,
@@ -100,7 +109,7 @@ object Utils {
   }
 
   // Return the data structure use to compute metrics reports for TaskMetrics
-  def zeroMetricsTask() : LinkedHashMap[String, Long] = {
+  def zeroMetricsTask(): LinkedHashMap[String, Long] = {
     val zeroedMetrics = LinkedHashMap(
       "numTasks" -> 0L,
       "successful tasks" -> 0L,
@@ -113,7 +122,7 @@ object Utils {
       "executorDeserializeCpuTime" -> 0L,
       "resultSerializationTime" -> 0L,
       "jvmGCTime" -> 0L,
-      "shuffleFetchWaitTime"-> 0L,
+      "shuffleFetchWaitTime" -> 0L,
       "shuffleWriteTime" -> 0L,
       "gettingResultTime" -> 0L,
       "resultSize" -> 0L,
@@ -161,11 +170,11 @@ object Utils {
       case TaskLocality.NO_PREF => 3
       case TaskLocality.ANY => 4
       case _ => -1 // Flag an unknown situation
-     }
+    }
   }
 
   // handle metrics format parameter
-  def parseMetricsFormat(conf: SparkConf, logger: Logger, defaultFormat:String) : String = {
+  def parseMetricsFormat(conf: SparkConf, logger: Logger, defaultFormat: String): String = {
     // handle metrics format parameter
     val metricsFormat = conf.get("spark.sparkmeasure.outputFormat", defaultFormat)
     metricsFormat match {
@@ -177,7 +186,7 @@ object Utils {
     metricsFormat
   }
 
-  def parsePrintToStdout(conf: SparkConf, logger: Logger, defaultVal:Boolean) : Boolean = {
+  def parsePrintToStdout(conf: SparkConf, logger: Logger, defaultVal: Boolean): Boolean = {
     val printToStdout = conf.getBoolean("spark.sparkmeasure.printToStdout", defaultVal)
     if (printToStdout == true) {
       logger.info(s"Will print metrics output to stdout in JSON format")
@@ -186,7 +195,7 @@ object Utils {
   }
 
   // handle metrics file name parameter except if writing to string / stdout
-  def parseMetricsFilename(conf: SparkConf, logger: Logger, defaultFileName:String) : String = {
+  def parseMetricsFilename(conf: SparkConf, logger: Logger, defaultFileName: String): String = {
     val metricsFileName = conf.get("spark.sparkmeasure.outputFilename", defaultFileName)
     if (metricsFileName.isEmpty) {
       logger.warn("No output file will be written. If you want to write the output to a file, " +
@@ -197,7 +206,7 @@ object Utils {
     metricsFileName
   }
 
-  def parseInfluxDBURL(conf: SparkConf, logger: Logger) : String = {
+  def parseInfluxDBURL(conf: SparkConf, logger: Logger): String = {
     // handle InfluxDB URL
     val influxdbURL = conf.get("spark.sparkmeasure.influxdbURL", "http://localhost:8086")
     if (influxdbURL.isEmpty) {
@@ -209,7 +218,7 @@ object Utils {
     influxdbURL
   }
 
-  def parseInfluxDBCredentials(conf: SparkConf, logger: Logger) : (String,String) = {
+  def parseInfluxDBCredentials(conf: SparkConf, logger: Logger): (String, String) = {
     // handle InfluxDB username and password
     val influxdbUsername = conf.get("spark.sparkmeasure.influxdbUsername", "")
     val influxdbPassword = conf.get("spark.sparkmeasure.influxdbPassword", "")
@@ -222,21 +231,21 @@ object Utils {
     (influxdbUsername, influxdbPassword)
   }
 
-  def parseInfluxDBName(conf: SparkConf, logger: Logger) : String = {
+  def parseInfluxDBName(conf: SparkConf, logger: Logger): String = {
     // handle InfluxDB username and password
     val influxdbName = conf.get("spark.sparkmeasure.influxdbName", "sparkmeasure")
     logger.info(s"InfluxDB name: $influxdbName")
     influxdbName
   }
 
-  def parseInfluxDBStagemetrics(conf: SparkConf, logger: Logger) : Boolean = {
+  def parseInfluxDBStagemetrics(conf: SparkConf, logger: Logger): Boolean = {
     // handle InfluxDB username and password
     val influxdbStagemetrics = conf.getBoolean("spark.sparkmeasure.influxdbStagemetrics", false)
     logger.info(s"Log also stagemetrics: ${influxdbStagemetrics.toString}")
     influxdbStagemetrics
   }
 
-  def parseKafkaConfig(conf: SparkConf, logger: Logger) : (String,String) = {
+  def parseKafkaConfig(conf: SparkConf, logger: Logger): (String, String) = {
     // handle Kafka broker and topic
     val broker = conf.get("spark.sparkmeasure.kafkaBroker", "")
     val topic = conf.get("spark.sparkmeasure.kafkaTopic", "")
@@ -249,7 +258,7 @@ object Utils {
     (broker, topic)
   }
 
-  def parsePushGatewayConfig(conf: SparkConf, logger: Logger): (String, String) = {
+  def parsePushGatewayConfig(conf: SparkConf, logger: Logger): PushgatewayConfig = {
     // handle Push Gateway URL
     val URL = conf.get("spark.sparkmeasure.pushgateway", "")
     if (URL.isEmpty) {
@@ -257,14 +266,18 @@ object Utils {
     } else {
       logger.info(s"Prometheus Push Gateway server and port: $URL")
     }
-    // sets the value for the label "job" reported with each metrics point
-    val job = conf.get("spark.sparkmeasure.pushgateway.jobname", "pushgateway")
-    (URL, job)
+
+    PushgatewayConfig(
+      URL,
+      jobName = conf.get("spark.sparkmeasure.pushgateway.jobname", "pushgateway"),
+      connectionTimeoutMs = Integer.parseInt(conf.get("spark.sparkmeasure.pushgateway.http.connection.timeout", "5000")),
+      readTimeoutMs = Integer.parseInt(conf.get("spark.sparkmeasure.pushgateway.http.read.timeout", "5000")),
+    )
   }
 
   // handle list of metrics to process by the listener onExecutorMetricsUpdate
   // returns an array with the metrics to process
-  def parseExecutorMetricsConfig(conf: SparkConf, logger: Logger) : Array[String] = {
+  def parseExecutorMetricsConfig(conf: SparkConf, logger: Logger): Array[String] = {
     val metrics = conf.get("spark.sparkmeasure.stageinfo.executormetrics",
       "JVMHeapMemory,OnHeapExecutionMemory")
     logger.info(s"Executor metrics being collected: ${metrics.toString}")
@@ -272,7 +285,7 @@ object Utils {
   }
 
   // boolean flag, turns on/off collecting and reporting additional stage info (duration and memory details)
-  def parseExtraStageMetrics(conf: SparkConf, logger: Logger) : Boolean = {
+  def parseExtraStageMetrics(conf: SparkConf, logger: Logger): Boolean = {
     // handle InfluxDB username and password
     val extraStageMetrics = conf.getBoolean("spark.sparkmeasure.stageinfo.verbose", true)
     logger.info(s"Collect and report extra stage metrics: ${extraStageMetrics.toString}")

--- a/src/test/scala/ch/cern/sparkmeasure/pushgatewayTest.scala
+++ b/src/test/scala/ch/cern/sparkmeasure/pushgatewayTest.scala
@@ -1,9 +1,10 @@
 package ch.cern.sparkmeasure
 
-import org.scalatest.{FlatSpec, Matchers}
-import java.net.ServerSocket
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock._
+import org.scalatest.{FlatSpec, Matchers}
+
+import java.net.ServerSocket
 
 class PushGatewayTest extends FlatSpec with Matchers {
 
@@ -14,7 +15,9 @@ class PushGatewayTest extends FlatSpec with Matchers {
     ip_port = socket.getLocalPort
     socket.close
   }
-  catch { case _: Throwable => }
+  catch {
+    case _: Throwable =>
+  }
 
   if (ip_port == 0) {
     it should "get available ip port" in {
@@ -30,7 +33,12 @@ class PushGatewayTest extends FlatSpec with Matchers {
     val serverIPnPort = s"localhost:" + ip_port.toString
     val metricsJob = s"aaa_job"
 
-    val pushGateway = PushGateway(serverIPnPort, metricsJob)
+    val pushGateway = PushGateway(
+      PushgatewayConfig(
+        serverIPnPort = serverIPnPort,
+        jobName = metricsJob
+      )
+    )
 
 
     /** Check metric name validation for Prometheus */
@@ -69,7 +77,7 @@ class PushGatewayTest extends FlatSpec with Matchers {
       .withRequestBody(containing(str_metrics))
       .willReturn(
         aResponse()
-        .withStatus(200)
+          .withStatus(200)
       )
     )
 


### PR DESCRIPTION
Hey, this PR adds the capability to configure the timeout for the PushGateway http connection, we have observed cases where large spark jobs (hundreds - thousands) of stages are lagging due to the generous 5000ms default timeout, our aim is to allow this behaviour to be configurable.

I also fixed some inconsistencies with the formatting, please let me know if this is an issue and you'd like me to revert.