### PR TITLE
Fix task metrics NullPointerException in KafkaSinkExtended

### DIFF
--- a/src/main/scala/ch/cern/sparkmeasure/KafkaSink.scala
+++ b/src/main/scala/ch/cern/sparkmeasure/KafkaSink.scala
@@ -298,7 +298,7 @@ class KafkaSinkExtended(conf: SparkConf) extends KafkaSink(conf) {
     )
     report(point1)
 
-    val point2 = Map[String, Any](
+    val taskMetricsHeader = Map[String, Any](
       "name" -> "task_metrics",
       "appId" -> appId,
       // task info
@@ -316,6 +316,9 @@ class KafkaSinkExtended(conf: SparkConf) extends KafkaSink(conf) {
       "successful" -> taskInfo.successful,
       "host" -> taskInfo.host,
       "taskLocality" -> Utils.encodeTaskLocality(taskInfo.taskLocality),
+      "epochMillis" -> epochMillis
+    )
+    val taskMetricsBody = if (taskmetrics != null) Map[String, Any](
       // task metrics
       "executorRunTime" -> taskmetrics.executorRunTime,
       "executorCpuTime" -> taskmetrics.executorCpuTime,
@@ -342,8 +345,8 @@ class KafkaSinkExtended(conf: SparkConf) extends KafkaSink(conf) {
       "shuffleBytesWritten" -> taskmetrics.shuffleWriteMetrics.bytesWritten,
       "shuffleRecordsWritten" -> taskmetrics.shuffleWriteMetrics.recordsWritten,
       "shuffleWriteTime" -> taskmetrics.shuffleWriteMetrics.writeTime,
-      "epochMillis" -> epochMillis
-    )
+    ) else Map()
+    val point2 = taskMetricsHeader ++ taskMetricsBody
     report(point2)
   }
 }


### PR DESCRIPTION
Fixes the following error in KafkaSinkExtended:
```
java.lang.NullPointerException: Cannot invoke "org.apache.spark.executor.TaskMetrics.executorRunTime()" because "taskmetrics" is null
        at ch.cern.sparkmeasure.KafkaSinkExtended.onTaskEnd(KafkaSink.scala:317)
        at org.apache.spark.scheduler.SparkListenerBus.doPostEvent(SparkListenerBus.scala:45)
        at org.apache.spark.scheduler.SparkListenerBus.doPostEvent$(SparkListenerBus.scala:28)
        at org.apache.spark.scheduler.AsyncEventQueue.doPostEvent(AsyncEventQueue.scala:37)
        at org.apache.spark.scheduler.AsyncEventQueue.doPostEvent(AsyncEventQueue.scala:37)
        at org.apache.spark.util.ListenerBus.postToAll(ListenerBus.scala:117)
        at org.apache.spark.util.ListenerBus.postToAll$(ListenerBus.scala:101)
        at org.apache.spark.scheduler.AsyncEventQueue.super$postToAll(AsyncEventQueue.scala:105)
        at org.apache.spark.scheduler.AsyncEventQueue.$anonfun$dispatch$1(AsyncEventQueue.scala:105)
        at scala.runtime.java8.JFunction0$mcJ$sp.apply(JFunction0$mcJ$sp.java:23)
        at scala.util.DynamicVariable.withValue(DynamicVariable.scala:62)
        at org.apache.spark.scheduler.AsyncEventQueue.org$apache$spark$scheduler$AsyncEventQueue$$dispatch(AsyncEventQueue.scala:100)
        at org.apache.spark.scheduler.AsyncEventQueue$$anon$2.$anonfun$run$1(AsyncEventQueue.scala:96)
        at org.apache.spark.util.Utils$.tryOrStopSparkContext(Utils.scala:1356)
        at org.apache.spark.scheduler.AsyncEventQueue$$anon$2.run(AsyncEventQueue.scala:96)
```